### PR TITLE
Fix support for Ruby 2.0.0 on Heroku.

### DIFF
--- a/lib/language_pack/base.rb
+++ b/lib/language_pack/base.rb
@@ -62,7 +62,6 @@ class LanguagePack::Base
 
     {
       "addons" => default_addons,
-      "config_vars" => default_config_vars,
       "default_process_types" => default_process_types
     }.to_yaml
   end
@@ -153,7 +152,7 @@ private ##################################
     %x{ #{command} 2>/dev/null }
   end
 
-  # run a shell command and stream the ouput
+  # run a shell command and stream the output
   # @param [String] command to be run
   def pipe(command)
     output = ""
@@ -222,5 +221,10 @@ private ##################################
     system("cp -a #{from}/. #{to}")
   end
 
+  # check if the cache content exists
+  # @param [String] relative path of the cache contents
+  # @param [Boolean] true if the path exists in the cache and false if otherwise
+  def cache_exists?(path)
+    File.exists?(cache_base + path)
+  end
 end
-

--- a/lib/language_pack/rails2.rb
+++ b/lib/language_pack/rails2.rb
@@ -73,8 +73,8 @@ private
 
   # most rails apps need a database
   # @return [Array] shared database addon
-  def add_shared_database_addon
-    ['shared-database:5mb']
+  def add_dev_database_addon
+    ['heroku-postgresql:dev']
   end
 
   # sets up the profile.d script for this buildpack
@@ -85,4 +85,3 @@ private
   end
 
 end
-

--- a/lib/language_pack/rails3.rb
+++ b/lib/language_pack/rails3.rb
@@ -8,7 +8,7 @@ class LanguagePack::Rails3 < LanguagePack::Rails2
   def self.use?
     super &&
       File.exists?("config/application.rb") &&
-      File.read("config/application.rb") =~ /Rails::Application/
+      File.read("config/application.rb").include?("Rails::Application")
   end
 
   def name

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -5,9 +5,10 @@ require "language_pack/base"
 
 # base Ruby Language Pack. This is for any base ruby app.
 class LanguagePack::Ruby < LanguagePack::Base
+  BUILDPACK_VERSION   = "v50"
   LIBYAML_VERSION     = "0.1.4"
   LIBYAML_PATH        = "libyaml-#{LIBYAML_VERSION}"
-  BUNDLER_VERSION     = "1.2.1"
+  BUNDLER_VERSION     = "1.3.0.pre.5"
   BUNDLER_GEM_PATH    = "bundler-#{BUNDLER_VERSION}"
   NODE_VERSION        = "0.4.7"
   NODE_JS_BINARY_PATH = "node-#{NODE_VERSION}"
@@ -25,7 +26,7 @@ class LanguagePack::Ruby < LanguagePack::Base
   end
 
   def default_addons
-    add_shared_database_addon
+    add_dev_database_addon
   end
 
   def default_config_vars
@@ -141,7 +142,7 @@ private
   # determine if we're using rbx
   # @return [Boolean] true if we are and false if we aren't
   def ruby_version_rbx?
-    ruby_version ? ruby_version.match(/^rbx-/) : false
+    ruby_version ? ruby_version.match(/rbx-/) : false
   end
 
   # determine if we're using jruby
@@ -159,7 +160,7 @@ private
   # default JRUBY_OPTS
   # return [String] string of JRUBY_OPTS
   def default_jruby_opts
-    "-Xcompile.invokedynamic=false"
+    "-Xcompile.invokedynamic=true"
   end
 
   # list the available valid ruby versions
@@ -191,12 +192,9 @@ private
 
   # sets up the profile.d script for this buildpack
   def setup_profiled
-    set_env_default  "GEM_PATH", "$HOME/#{slug_vendor_base}"
+    set_env_override "GEM_PATH", "$HOME/#{slug_vendor_base}:$GEM_PATH"
     set_env_default  "LANG",     "en_US.UTF-8"
     set_env_override "PATH",     "$HOME/bin:$HOME/#{slug_vendor_base}/bin:$PATH"
-    # set_env_override "LIBRARY_PATH", "vendor/freetds/lib:$LIBRARY_PATH"
-    # set_env_override "CPATH", "$HOME/vendor/freetds/include:$CPATH"
-    # set_env_override "CPPATH", "$HOME/vendor/freetds/include:$CPPATH"
     set_env_override "LD_LIBRARY_PATH", "vendor/freetds/lib:$LD_LIBRARY_PATH"
 
     if ruby_version_jruby?
@@ -208,7 +206,7 @@ private
   # determines if a build ruby is required
   # @return [Boolean] true if a build ruby is required
   def build_ruby?
-    @build_ruby ||= !ruby_version_jruby? && ruby_version != "ruby-1.9.3"
+    @build_ruby ||= !ruby_version_rbx? && !ruby_version_jruby? && !%w{ruby-1.9.3 ruby-2.0.0}.include?(ruby_version)
   end
 
   # install the vendored ruby
@@ -366,13 +364,17 @@ ERROR
   def build_bundler
     log("bundle") do
       bundle_without = ENV["BUNDLE_WITHOUT"] || "development:test"
-      bundle_command = "bundle install --without #{bundle_without} --path vendor/bundle --binstubs bin/"
+      bundle_command = "bundle install --without #{bundle_without} --path vendor/bundle --binstubs vendor/bundle/bin"
 
       unless File.exist?("Gemfile.lock")
         error "Gemfile.lock is required. Please run \"bundle install\" locally\nand commit your Gemfile.lock."
       end
 
       if has_windows_gemfile_lock?
+        topic "WARNING: Removing `Gemfile.lock` because it was generated on Windows."
+        puts "Bundler will do a full resolve so native gems are handled properly."
+        puts "This may result in unexpected gem versions being used in your app."
+
         log("bundle", "has_windows_gemfile_lock")
         File.unlink("Gemfile.lock")
       else
@@ -384,7 +386,7 @@ ERROR
       version = run("env RUBYOPT=\"#{syck_hack}\" bundle version").strip
       topic("Installing dependencies using #{version}")
 
-      cache_load "vendor/bundle"
+      load_bundler_cache
 
       bundler_output = ""
       Dir.mktmpdir("libyaml-") do |tmpdir|
@@ -393,9 +395,9 @@ ERROR
 
         # freetds_dir = "#{tmpdir}/freetds"
         # `mkdir -p #{tmpdir}/freetds`
-
+ 
         # `curl https://s3.amazonaws.com/firmhouse/freetds-0.tgz -o - | tar -xz -C #{tmpdir}/freetds -f -`
-
+ 
         # freetds_include = File.expand_path("#{freetds_dir}/include")
         # freetds_lib = File.expand_path("#{freetds_dir}/lib")
 
@@ -420,6 +422,13 @@ ERROR
 
         # Keep gem cache out of the slug
         FileUtils.rm_rf("#{slug_vendor_base}/cache")
+
+        # symlink binstubs
+        bin_dir = "bin"
+        FileUtils.mkdir_p bin_dir
+        Dir["#{slug_vendor_base}/bin/*"].each do |bin|
+          run("ln -s ../#{bin} #{bin_dir}") unless File.exist?("#{bin_dir}/#{bin}")
+        end
       else
         log "bundle", :status => "failure"
         error_message = "Failed to install gems via Bundler."
@@ -562,10 +571,10 @@ params = CGI.parse(uri.query || "")
     ENV["GIT_DIR"] = git_dir
   end
 
-  # decides if we need to enable the shared database addon
+  # decides if we need to enable the dev database addon
   # @return [Array] the database addon if the pg gem is detected or an empty Array if it isn't.
-  def add_shared_database_addon
-    gem_is_bundled?("pg") ? ['shared-database:5mb'] : []
+  def add_dev_database_addon
+    gem_is_bundled?("pg") ? ['heroku-postgresql:dev'] : []
   end
 
   # decides if we need to install the node.js binary
@@ -585,5 +594,51 @@ params = CGI.parse(uri.query || "")
         puts "Asset precompilation completed (#{"%.2f" % time}s)"
       end
     end
+  end
+
+  def bundler_cache
+    "vendor/bundle"
+  end
+
+  def load_bundler_cache
+    cache_load "vendor"
+
+    full_ruby_version       = run(%q(ruby -v)).chomp
+    heroku_metadata         = "vendor/heroku"
+    ruby_version_cache      = "#{heroku_metadata}/ruby_version"
+    buildpack_version_cache = "vendor/heroku/buildpack_version"
+
+    # fix bug from v37 deploy
+    if File.exists?("vendor/ruby_version")
+      puts "Broken cache detected. Purging build cache."
+      cache_clear("vendor")
+      FileUtils.rm_rf("vendor/ruby_version")
+      purge_bundler_cache
+    # fix bug introduced in v38
+    elsif !File.exists?(buildpack_version_cache) && File.exists?(ruby_version_cache)
+      puts "Broken cache detected. Purging build cache."
+      purge_bundler_cache
+    elsif cache_exists?(bundler_cache) && File.exists?(ruby_version_cache) && full_ruby_version != File.read(ruby_version_cache).chomp
+      puts "Ruby version change detected. Clearing bundler cache."
+      puts "Old: #{File.read(ruby_version_cache).chomp}"
+      puts "New: #{full_ruby_version}"
+      purge_bundler_cache
+    end
+
+    FileUtils.mkdir_p(heroku_metadata)
+    File.open(ruby_version_cache, 'w') do |file|
+      file.puts full_ruby_version
+    end
+    File.open(buildpack_version_cache, 'w') do |file|
+      file.puts BUILDPACK_VERSION
+    end
+    cache_store heroku_metadata
+  end
+
+  def purge_bundler_cache
+    FileUtils.rm_rf(bundler_cache)
+    cache_clear bundler_cache
+    # need to reinstall language pack gems
+    install_language_pack_gems
   end
 end


### PR DESCRIPTION
Heroku just updated to Ruby 2.0.0rc2 and in the process the buildpack won't install because it can't find ruby 2.0.0.

I have merged in the changes from the Heroku build packs with this one to fix the incompatibility.
